### PR TITLE
forcing lastun to be always today

### DIFF
--- a/Fetch - Catalog.ps1
+++ b/Fetch - Catalog.ps1
@@ -33,8 +33,6 @@ try {
         $state | Add-Member -NotePropertyName "Catalog" -NotePropertyValue @{"LastRun" = $null; "LastFullScan" = $null } -Force
     }
     
-    $state.Catalog.LastRun = [datetime]::UtcNow.Date.ToString("o")
-
     # ensure folders
     
     $scansOutputPath = Join-Path $outputPath ("scans\{0:yyyy}\{0:MM}\{0:dd}" -f [datetime]::Today)


### PR DESCRIPTION
That line I removed was forcing the Catalog script to consider the last run as today, ignoring the date that was in the State.json. I think that this line was left by mistake.